### PR TITLE
Support for unbuffered comments (fix #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,26 @@ This would render as:
 
 For any type of content transforms that are more complex than this, we recommend checking out [posthtml-content](https://github.com/posthtml/posthtml-content).
 
+#### Comments
+
+You can use buffered `//` and unbuffered `//-` comments. Only buffered comments would be compiled into the html output.
+
+```
+// just some text
+p Paragraph after buffered comment
+
+//- will not output within markup
+p Paragraph after unbuffered comment
+```
+
+This would render as:
+
+```html
+<!-- just some text -->
+<p>Paragraph after buffered comment</p>
+<p>Paragraph after unbuffered comment</p>
+```
+
 <h2 align="center">Example</h2>
 
 ```

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -283,7 +283,7 @@ module.exports = function Lexer (input) {
       // move past the two slashes
       next(); next()
 
-      // if there is a space, then unbuffered comment and we should skip it
+      // if there is a dash, then unbuffered comment and we should skip it
       if (char === '-') {
         while (char && char !== '\n') {
           next()

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -283,6 +283,15 @@ module.exports = function Lexer (input) {
       // move past the two slashes
       next(); next()
 
+      // if there is a space, then unbuffered comment and we should skip it
+      if (char === '-') {
+        while (char && char !== '\n') {
+          next()
+        }
+
+        return
+      }
+
       // if there is a space, move past that
       if (char.match(/\s/)) next()
 

--- a/test/expect/comment.html
+++ b/test/expect/comment.html
@@ -1,1 +1,1 @@
-<!-- here's a thing --><p>wow</p>
+<!-- here's a thing --><p>wow</p><p>wow</p>

--- a/test/fixtures/comment.html
+++ b/test/fixtures/comment.html
@@ -1,2 +1,5 @@
 // here's a thing
 p wow
+
+//- will not output within markup
+p wow


### PR DESCRIPTION
## Proposed Changes

Support for unbuffered comments.

#### Comments

You can use buffered `//` and unbuffered `//-` comments. Only buffered comments would be compiled into the html output.

```
// just some text
p Paragraph after buffered comment

//- will not output within markup
p Paragraph after unbuffered comment
```

This would render as:

```html
<!-- just some text -->
<p>Paragraph after buffered comment</p>
<p>Paragraph after unbuffered comment</p>
```

## Types of Changes

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature which changes existing functionality)